### PR TITLE
Release/1.1.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Publish collector locally
       run: |
-        git clone --branch 2.1.0 --depth 1 https://github.com/snowplow/stream-collector.git
+        git clone --branch 2.2.1 --depth 1 https://github.com/snowplow/stream-collector.git
         cd stream-collector
         sbt publishLocal
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Publish collector locally
       run: |
-        git clone --branch 2.1.0 --depth 1 https://github.com/snowplow/stream-collector.git
+        git clone --branch 2.2.1 --depth 1 https://github.com/snowplow/stream-collector.git
         cd stream-collector
         sbt publishLocal
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = project
   .settings(
     name := "snowplow-micro",
     organization := "com.snowplowanalytics.snowplow",
-    version := "1.1.0",
+    version := "1.1.1",
     description := "Standalone application to automate testing of trackers",
     scalaVersion := "2.12.11",
     scalacOptions := Settings.compilerOptions,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
 
   object V {
     // Snowplow
-    val snowplowStreamCollector = "2.1.0"
+    val snowplowStreamCollector = "2.2.1"
     val snowplowCommonEnrich    = "1.4.2"
 
     // circe


### PR DESCRIPTION
I'd put this together to test the 2.2.1 collector release and to test the updated anonymous tracking functionality with the latest JS Tracker release. 

It would be good to update the JS Tracker automated tests to use stream-collector 2.2.1 so opening this 1.1.1 PR 😊 