### PR TITLE
Provide a way to use local Iglu schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ java -jar snowplow-micro-1.1.2.jar --collector-config example/micro.conf --iglu 
 If `schemas/` folder holding the Iglu schemas is in `$(pwd)/iglu-schemas/`, this parameter must be added to `docker run`:
 `--mount type=bind,source=$(pwd)/iglu-schemas,destination=/iglu-schemas`.
 
+If schema `iglu:foo/bar/jsonschema/1-0-0` is needed inside macro, then the file `$(pwd)/iglu-schemas/schemas/foo/bar/jsonschema/1-0-0` must exist.
+
 The container embeds an HTTP server that serves `/iglu-schemas` and listens to `8080`.
 These lines must be added to the resolver:
 ```
@@ -57,6 +59,8 @@ These lines must be added to the resolver:
 ```
 
 It's possible to override the default `8080` by adding `-e IGLU_PORT=xxx` to `docker run` command.
+
+To check that local schemas are correctly mounted, `schemas/` should appear in the browser at `localhost:8080` address, after having configured the port in `docker run` (`-p 8080:8080` or the port specified in `IGLU_PORT`).
 
 ## 3. REST API
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These lines must be added to the resolver:
 ```
 
 It's possible to override the default `8080` by adding `-e IGLU_PORT=xxx` to `docker run` command.
+In this case the port in the resolver must also get updated to match.
 
 To check that local schemas are correctly mounted, `schemas/` should appear in the browser at `localhost:8080` address, after having configured the port in `docker run` (`-p 8080:8080` or the port specified in `IGLU_PORT`).
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ These lines must be added to the resolver:
 }
 ```
 
+It's possible to override the default `8080` by adding `-e IGLU_PORT=xxx` to `docker run` command.
+
 ## 3. REST API
 
 Snowplow Micro offers 4 endpoints to query the data recorded.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ Alternatively, a Snowplow Micro jar file is hosted on the [Github release page](
 java -jar snowplow-micro-1.1.2.jar --collector-config example/micro.conf --iglu example/iglu.json
 ```
 
+#### Use custom schemas from local folder
+
+If `schemas/` folder holding the Iglu schemas is in `$(pwd)/iglu-schemas/`, this parameter must be added to `docker run`:
+`--mount type=bind,source=$(pwd)/iglu-schemas,destination=/iglu-schemas`.
+
+The container embeds an HTTP server that serves `/iglu-schemas` and listens to `8080`.
+These lines must be added to the resolver:
+```
+{
+  "name": "Micro's Iglu /iglu-schemas",
+  "priority": 100,
+  "vendorPrefixes": [ "com.snowplowanalytics" ],
+  "connection": {
+    "http": {
+      "uri": "http://localhost:8080"
+    }
+  }
+}
+```
+
 ## 3. REST API
 
 Snowplow Micro offers 4 endpoints to query the data recorded.

--- a/build.sbt
+++ b/build.sbt
@@ -36,12 +36,19 @@ lazy val root = project
       scalaVersion),
     buildInfoPackage := "buildinfo"
   )
-
 import com.typesafe.sbt.packager.docker._
 enablePlugins(JavaAppPackaging)
 enablePlugins(DockerPlugin)
 packageName in Docker := "snowplow/snowplow-micro"
 maintainer in Docker := "Snowplow Analytics Ltd. <support@snowplowanalytics.com>"
-dockerBaseImage := "snowplow-docker-registry.bintray.io/snowplow/base-debian:0.2.1"
+dockerBaseImage := "snowplow/base-debian:0.2.1"
 daemonUser in Docker := "snowplow"
 dockerUpdateLatest := true
+mappings in Universal += (file(s"${baseDirectory.value}/entrypoint.sh") -> "entrypoint.sh")
+dockerCommands ++= Seq(
+  Cmd("USER", "root"),
+  Cmd("RUN", "apt-get", "update"),
+  Cmd("RUN", "apt-get", "install", "-y", "python3"),
+  Cmd("COPY", "/opt/docker/entrypoint.sh", "/entrypoint.sh"),
+  Cmd("ENTRYPOINT", "[\"bash\", \"/entrypoint.sh\"]")
+)

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = project
   .settings(
     name := "snowplow-micro",
     organization := "com.snowplowanalytics.snowplow",
-    version := "1.1.2",
+    version := "1.1.3-rc3",
     description := "Standalone application to automate testing of trackers",
     scalaVersion := "2.12.11",
     scalacOptions := Settings.compilerOptions,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,13 @@
-python3 -m http.server 8080 --directory /iglu-schemas &
+if [ -n "$IGLU_PORT" ]
+then
+  port=$IGLU_PORT
+else
+  port=8080
+fi
 
-/opt/docker/bin/snowplow-micro $@
+if [ -n "$(ls -A /iglu-schemas 2>/dev/null)" ]
+then
+  python3 -m http.server $port --directory /iglu-schemas &
+fi
+
+exec /opt/docker/bin/snowplow-micro $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+python3 -m http.server 8080 --directory /iglu-schemas &
+
+/opt/docker/bin/snowplow-micro $@

--- a/example/iglu.json
+++ b/example/iglu.json
@@ -12,6 +12,16 @@
               "uri": "http://iglucentral.com"
             }
           }
+        },
+        {
+          "name": "Micro's Iglu /iglu-schemas",
+          "priority": 100,
+          "vendorPrefixes": [ "com.snowplowanalytics" ],
+          "connection": {
+            "http": {
+              "uri": "http://localhost:8080"
+            }
+          }
         }
       ]
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.24")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
Python's `http.server` is used to serve a mounted volume and use it as an Iglu endpoint.

This works as such :
- create script `entrypoint.sh` that is the new entrypoint
- this script runs the HTTP server in the background and serves `/iglu-schemas` (works if not mounted)
- it then runs Micro binary
- the parameters that are passed at the end of the `docker run` command (`--config ...)` are passed back to the binary with `$@`.