### PR TITLE
Bump collector to 2.6.0 and enrich to 3.1.3 (close #79)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Publish collector locally
       run: |
-        git clone --branch 2.3.1 --depth 1 https://github.com/snowplow/stream-collector.git
+        git clone --branch 2.6.0 --depth 1 https://github.com/snowplow/stream-collector.git
         cd stream-collector
         sbt publishLocal
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Publish collector locally
       run: |
-        git clone --branch 2.3.1 --depth 1 https://github.com/snowplow/stream-collector.git
+        git clone --branch 2.6.0 --depth 1 https://github.com/snowplow/stream-collector.git
         cd stream-collector
         sbt publishLocal
 

--- a/example/micro.conf
+++ b/example/micro.conf
@@ -1,0 +1,19 @@
+# 'collector' contains configuration options for the main Scala collector.
+collector {
+  # The collector responds with a cookie to requests with a path that matches the 'vendor/version' protocol.
+  # The expected values are:
+  # - com.snowplowanalytics.snowplow/tp2 for Tracker Protocol 2
+  # - r/tp2 for redirects
+  # - com.snowplowanalytics.iglu/v1 for the Iglu Webhook
+  # Any path that matches the 'vendor/version' protocol will result in a cookie response, for use by custom webhooks
+  # downstream of the collector.
+  # But you can also map any valid (i.e. two-segment) path to one of the three defaults.
+  # Your custom path must be the key and the value must be one of the corresponding default paths. Both must be full
+  # valid paths starting with a leading slash.
+  # Pass in an empty map to avoid mapping.
+  paths {
+    # "/com.acme/track" = "/com.snowplowanalytics.snowplow/tp2"
+    # "/com.acme/redirect" = "/r/tp2"
+    # "/com.acme/iglu" = "/com.snowplowanalytics.iglu/v1"
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,8 +16,8 @@ object Dependencies {
 
   object V {
     // Snowplow
-    val snowplowStreamCollector = "2.3.1"
-    val snowplowCommonEnrich    = "2.0.2"
+    val snowplowStreamCollector = "2.6.0"
+    val snowplowCommonEnrich    = "3.1.3"
 
     // circe
     val circe = "0.14.1"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -194,7 +194,7 @@ collector {
   redirectDomains     = []
   enableStartupChecks = true
   terminationDeadline = 10.seconds
-  preTerminationPeriod = 10.seconds
+  preTerminationPeriod = 0.seconds
   preTerminationUnhealthy = false
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -145,13 +145,16 @@ collector {
     accessControlMaxAge = 5 seconds
   }
 
-  # Configuration of prometheus http metrics
-  prometheusMetrics {
-    # If metrics are enabled then all requests will be logged as prometheus metrics
-    # and '/metrics' endpoint will return the report about the requests
+
+  monitoring.metrics.statsd {
     enabled = false
-    # Custom buckets for http_request_duration_seconds_bucket duration metric
-    #durationBucketsInSeconds = [0.1, 3, 10]
+    # StatsD metric reporting protocol configuration
+    hostname = localhost
+    port = 8125
+    # Required, how frequently to report metrics
+    period = "10 seconds"
+    # Optional, override the default metric prefix
+    # "prefix": "snowplow.collector"
   }
 
   streams {
@@ -186,6 +189,13 @@ collector {
       timeLimit = 1000
     }
   }
+
+  enableDefaultRedirect = false
+  redirectDomains     = []
+  enableStartupChecks = true
+  terminationDeadline = 10.seconds
+  preTerminationPeriod = 10.seconds
+  preTerminationUnhealthy = false
 }
 
 # Akka has a variety of possible configuration options defined at

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
@@ -109,7 +109,7 @@ private[micro] final case class MemorySink(igluClient: Client[Id, Json]) extends
     enrichmentRegistry: EnrichmentRegistry[Id],
     processor: Processor
   ): Either[List[String], GoodEvent] =
-    EnrichmentManager.enrichEvent[Id](enrichmentRegistry, igluClient, processor, DateTime.now(), rawEvent)
+    EnrichmentManager.enrichEvent[Id](enrichmentRegistry, igluClient, processor, DateTime.now(), rawEvent, false, ())
       .subflatMap { enriched =>
         EventConverter.fromEnriched(enriched)
           .leftMap { failure =>
@@ -130,4 +130,5 @@ private[micro] final case class MemorySink(igluClient: Client[Id, Json]) extends
   private[micro] def getEnrichedContexts(enriched: Event): List[String] =
     enriched.contexts.data.map(_.schema.toSchemaUri)
 
+  override def shutdown(): Unit = ()
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Routing.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Routing.scala
@@ -20,7 +20,7 @@ import akka.http.scaladsl.model.{HttpMethods, StatusCodes}
 import io.circe.generic.auto._
 
 import com.snowplowanalytics.snowplow.collectors.scalastream.model.{CollectorConfig, CollectorSinks}
-import com.snowplowanalytics.snowplow.collectors.scalastream.{CollectorRoute, CollectorService}
+import com.snowplowanalytics.snowplow.collectors.scalastream.{CollectorRoute, CollectorService, HealthService}
 
 import scala.concurrent.ExecutionContext
 
@@ -45,9 +45,12 @@ private[micro] object Routing {
       collectorSinks: CollectorSinks,
       igluService: IgluService
   )(implicit ec: ExecutionContext): Route = {
-    val c = new CollectorService(collectorConf, collectorSinks)
+    val c = new CollectorService(collectorConf, collectorSinks, buildinfo.BuildInfo.name, buildinfo.BuildInfo.version)
+
+    val health = new HealthService.Settable
     val collectorRoutes = new CollectorRoute {
       override def collectorService = c
+      override def healthService    = health
     }.collectorRoute
 
     withCors(c) {

--- a/src/test/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/EventConverterSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/EventConverterSpec.scala
@@ -92,15 +92,6 @@ class EventConverterSpec extends Specification {
       }
     }
 
-    "should correctly convert string to optional int fields" >> {
-      val enriched = newValidEvent
-      enriched.txn_id = "42"
-      val result = EventConverter.fromEnriched(enriched)
-      result.toEither must beRight { e: Event =>
-        e.txn_id must beSome(42)
-      }
-    }
-
     "should correctly convert missing string to optional int fields" >> {
       val enriched = newValidEvent
       enriched.txn_id = null


### PR DESCRIPTION
This PR bumps collector and enrich, along with fixing resulting issues.

- bump collector version to 2.6.0
- bump enrich version to 3.1.3
- make `--collector-config` and `--iglu` flags optional

A few errors occurred due to the bumps:

1. `CollectorService` now takes two new arguments, `appName` and `appVersion`. These are taken from the `BuildInfo` plugin

2. `EnrichmentManager.enrichEvent` now takes two additional arguments, `acceptInvalid` and `invalidCount`. These are to do with easing a transition to a subtle breaking change

- The future behaviour of `acceptInvalid` will be `false` and has been set as such
- `invalidCount` is for monitoring if events are impacted by the change, and is not required for micro, so has been set to `()`

3. `CollectorRoute` requires `HealthService`.

4. As MemorySink extends `Sink` it is required to implement all the methods present in `Sink`. As `MemorySink` does not implement `shutdown`, it requires implementation to prevent an error

And a couple of warnings were fixed:

1. `bindAndHandle` is deprecated (since 10.2.0) and has been replaced with `newServerAt().bind()`

2. `ActorMaterializer` was un-used and has been removed

The functionality tested by the "convert string to optional int fields" test is no longer required, as there are no fields that require a string conversion to an optional int. This test has been removed.