### PR TITLE
Update example micro.conf (close #80)

### DIFF
--- a/example/micro.conf
+++ b/example/micro.conf
@@ -145,13 +145,15 @@ collector {
     accessControlMaxAge = 5 seconds
   }
 
-  # Configuration of prometheus http metrics
-  prometheusMetrics {
-    # If metrics are enabled then all requests will be logged as prometheus metrics
-    # and '/metrics' endpoint will return the report about the requests
+  monitoring.metrics.statsd {
     enabled = false
-    # Custom buckets for http_request_duration_seconds_bucket duration metric
-    #durationBucketsInSeconds = [0.1, 3, 10]
+    # StatsD metric reporting protocol configuration
+    hostname = localhost
+    port = 8125
+    # Required, how frequently to report metrics
+    period = "10 seconds"
+    # Optional, override the default metric prefix
+    # "prefix": "snowplow.collector"
   }
 
   streams {
@@ -186,6 +188,13 @@ collector {
       timeLimit = 1000
     }
   }
+
+  enableDefaultRedirect = false
+  redirectDomains     = []
+  enableStartupChecks = true
+  terminationDeadline = 10.seconds
+  preTerminationPeriod = 10.seconds
+  preTerminationUnhealthy = false
 }
 
 # Akka has a variety of possible configuration options defined at


### PR DESCRIPTION
There are new required keys for the collector block of `example/micro.conf` due to the bump to collector 2.6.0

- prometheus metrics have been replaced with statsd (see https://github.com/snowplow/stream-collector/commit/2045d600efe24725eb1c4d629b500cf138dd621e) requiring `monitoring.metrics.statsd`

- `terminationDeadline`, `preTerminationPeriod`, and `preTerminationUnhealthy` introduced in:
https://github.com/snowplow/stream-collector/commit/75ae270793d0b7bb99a7e7afb7b382405c88a730

- `redirectDomains` introduced in:
https://github.com/snowplow/stream-collector/commit/c05e52f2bc25b2ee80a032ccaf77365201089db0

- `enableDefaultRedirect` and `enableStartupChecks` introduced in:
https://github.com/snowplow/stream-collector/commit/53dab2dbbe644f4aa50b337ecdc7dce50b746e4b