### PR TITLE
Fix `no main manifest atrribute` error on micro distroless run (close #91)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val microSettingsDistroless = dockerCommon ++ Seq(
     s"/opt/snowplow/lib/${(packageJavaLauncherJar / artifactPath).value.getName}"
   ),
   dockerPermissionStrategy := DockerPermissionStrategy.CopyChown,
+  sourceDirectory := (micro / sourceDirectory).value
 )
 
 lazy val microSettings = dockerCommon ++ Seq(


### PR DESCRIPTION
- add `sourceDirectory` to val `microSettingsDistroless`