### PR TITLE
 Fix `discarded non-Unit value` warning on build (close #92)

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
@@ -49,7 +49,6 @@ private[micro] final case class MemorySink(igluClient: Client[Id, Json]) extends
   /** Function of the [[Sink]] called for all the events received by a collector. */
   override def storeRawEvents(events: List[Array[Byte]], key: String) = {
     events.foreach(bytes => processThriftBytes(bytes, igluClient, enrichmentRegistry, processor))
-    Nil
   }
 
   /** Deserialize Thrift bytes into `CollectorPayload`s,


### PR DESCRIPTION
This was related to this change: https://github.com/snowplow/stream-collector/commit/49bf3048906bcdfcd95e6aa8cb0594f8d25da1a7, but can be safely removed now.