### PR TITLE
Bump enrich to 3.3.1 (close #100)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   object V {
     // Snowplow
     val snowplowStreamCollector = "2.6.0"
-    val snowplowCommonEnrich    = "3.1.3"
+    val snowplowCommonEnrich    = "3.3.1"
 
     // circe
     val circe = "0.14.1"

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
@@ -33,6 +33,7 @@ import com.snowplowanalytics.snowplow.enrich.common.utils.ConversionUtils
 
 import com.snowplowanalytics.snowplow.badrows.Processor
 import IdImplicits._
+import com.snowplowanalytics.snowplow.enrich.common.EtlPipeline
 
 /** Sink of the collector that Snowplow Micro is.
   * Contains the functions that are called for each tracking event sent
@@ -108,7 +109,7 @@ private[micro] final case class MemorySink(igluClient: Client[Id, Json]) extends
     enrichmentRegistry: EnrichmentRegistry[Id],
     processor: Processor
   ): Either[List[String], GoodEvent] =
-    EnrichmentManager.enrichEvent[Id](enrichmentRegistry, igluClient, processor, DateTime.now(), rawEvent, false, ())
+    EnrichmentManager.enrichEvent[Id](enrichmentRegistry, igluClient, processor, DateTime.now(), rawEvent, EtlPipeline.FeatureFlags(acceptInvalid = false, legacyEnrichmentOrder = false), ())
       .subflatMap { enriched =>
         EventConverter.fromEnriched(enriched)
           .leftMap { failure =>


### PR DESCRIPTION
- update `EnrichmentManager.enrichEvent` to use FeatureFlags with `acceptInvalid` and `legacyEnrichmentOrder` set false

This resolves the following vulnerabilities in Micro: 
- https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
- https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2970521
- https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360


