### PR TITLE
Add `experimental` key (close #112)

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -196,6 +196,13 @@ collector {
   terminationDeadline = 10.seconds
   preTerminationPeriod = 0.seconds
   preTerminationUnhealthy = false
+  experimental {
+    warmup {
+      enable = false
+      numRequests = 2000
+      maxConnections = 2000
+    }
+  }
 }
 
 # Akka has a variety of possible configuration options defined at


### PR DESCRIPTION
The Micro 1.3.2 release updated Stream Collector to 2.7.1. As part of the previous 2.7.0 release, a new key, `experimental` was added to the Stream Collector config. Without this key, the parsing of the config file fails, meaning Micro fails to start.

This has now been added to the Micro default collector config file.