### PR TITLE
Release/1.3.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 1.3.3 (2022-09-13)
+--------------------------
+Add `experimental` key (#112)
+Add test for invalid default collector config (#115)
+
 Version 1.3.2 (2022-09-09)
 --------------------------
 Bump enrich to 3.3.1 (#100)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Snowplow Micro is hosted on Docker Hub ([snowplow/snowplow-micro][docker-micro])
 The following command can be used to run Micro with the default configuration:
 
 ```bash
-docker run -p 9090:9090 snowplow/snowplow-micro:1.3.2
+docker run -p 9090:9090 snowplow/snowplow-micro:1.3.3
 ```
 
 A [distroless][distroless-repo] image is also provided, which benefits from being smaller and more secure, with the downside of basic utilities (such as a shell) not being present in the image.
 
-The distroless image is tagged as `snowplow/snowplow-micro:1.3.2-distroless` on Docker Hub.
+The distroless image is tagged as `snowplow/snowplow-micro:1.3.3-distroless` on Docker Hub.
 
 #### Configuring Micro
 
@@ -43,7 +43,7 @@ The configuration files must be placed in a folder that is mounted in the Docker
 docker run \
   --mount type=bind,source=$(pwd)/example,destination=/config \
   -p 9090:9090 \
-  snowplow/snowplow-micro:1.3.2 \
+  snowplow/snowplow-micro:1.3.3 \
   --collector-config /config/micro.conf \
   --iglu /config/iglu.json
 ```
@@ -67,16 +67,16 @@ example
 If you cannot use Docker, a Snowplow Micro jar file is hosted on the [Github releases][gh-releases]. As an example, run Micro as:
 
 ```bash
-java -jar snowplow-micro-1.3.2.jar --collector-config example/micro.conf --iglu example/iglu.json
+java -jar snowplow-micro-1.3.3.jar --collector-config example/micro.conf --iglu example/iglu.json
 ```
 
 In case you also want an embedded Iglu, apply the same directory structure as shown above and run for example:
 
 ```bash
 # Unix
-java -cp snowplow-micro-1.3.2.jar:example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
+java -cp snowplow-micro-1.3.3.jar:example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
 # Windows
-java -cp snowplow-micro-1.3.2.jar;example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
+java -cp snowplow-micro-1.3.3.jar;example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
 ```
 
 ### Send events and start testing

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -196,6 +196,13 @@ collector {
   terminationDeadline = 10.seconds
   preTerminationPeriod = 0.seconds
   preTerminationUnhealthy = false
+  experimental {
+    warmup {
+      enable = false
+      numRequests = 2000
+      maxConnections = 2000
+    }
+  }
 }
 
 # Akka has a variety of possible configuration options defined at

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/ConfigHelperSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/ConfigHelperSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.micro
+
+import org.specs2.mutable.Specification
+
+class ConfigHelperSpec extends Specification {
+  "ConfigHelper" >> {
+    "will produce a valid parsed collector config if `--collector-config` is not present" >> {
+      ConfigHelper.parseConfig(Array()) must not(throwA[Exception])
+    }
+  }
+}


### PR DESCRIPTION
This release is a fix for the 1.3.2 release, where the `experimental` key was not added to the default collector config file, causing Micro to fail to start.