### PR TITLE
Prepare for 1.3.4 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 1.3.4 (2022-11-02)
+--------------------------
+Ensure docker image has latest openssl version (#120)
+
 Version 1.3.3 (2022-09-13)
 --------------------------
 Add `experimental` key (#112)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Snowplow Micro is hosted on Docker Hub ([snowplow/snowplow-micro][docker-micro])
 The following command can be used to run Micro with the default configuration:
 
 ```bash
-docker run -p 9090:9090 snowplow/snowplow-micro:1.3.3
+docker run -p 9090:9090 snowplow/snowplow-micro:1.3.4
 ```
 
 A [distroless][distroless-repo] image is also provided, which benefits from being smaller and more secure, with the downside of basic utilities (such as a shell) not being present in the image.
 
-The distroless image is tagged as `snowplow/snowplow-micro:1.3.3-distroless` on Docker Hub.
+The distroless image is tagged as `snowplow/snowplow-micro:1.3.4-distroless` on Docker Hub.
 
 #### Configuring Micro
 
@@ -43,7 +43,7 @@ The configuration files must be placed in a folder that is mounted in the Docker
 docker run \
   --mount type=bind,source=$(pwd)/example,destination=/config \
   -p 9090:9090 \
-  snowplow/snowplow-micro:1.3.3 \
+  snowplow/snowplow-micro:1.3.4 \
   --collector-config /config/micro.conf \
   --iglu /config/iglu.json
 ```
@@ -67,16 +67,16 @@ example
 If you cannot use Docker, a Snowplow Micro jar file is hosted on the [Github releases][gh-releases]. As an example, run Micro as:
 
 ```bash
-java -jar snowplow-micro-1.3.3.jar --collector-config example/micro.conf --iglu example/iglu.json
+java -jar snowplow-micro-1.3.4.jar --collector-config example/micro.conf --iglu example/iglu.json
 ```
 
 In case you also want an embedded Iglu, apply the same directory structure as shown above and run for example:
 
 ```bash
 # Unix
-java -cp snowplow-micro-1.3.3.jar:example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
+java -cp snowplow-micro-1.3.4.jar:example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
 # Windows
-java -cp snowplow-micro-1.3.3.jar;example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
+java -cp snowplow-micro-1.3.4.jar;example com.snowplowanalytics.snowplow.micro.Main --collector-config example/micro.conf --iglu example/iglu.json
 ```
 
 ### Send events and start testing


### PR DESCRIPTION
To resolve #120 .
Latest `eclipse-temurin:11` has just been published which includes base ubuntu image with patched openssl version.