### PR TITLE
Add MICRO_IGLU_REGISTRY_URL and MICRO_IGLU_API_KEY environment variables

### DIFF
--- a/src/main/resources/default-iglu-resolver.json
+++ b/src/main/resources/default-iglu-resolver.json
@@ -5,8 +5,8 @@
     "repositories": [
       {
         "name": "Iglu Central",
-        "priority": 0,
-        "vendorPrefixes": [ "com.snowplowanalytics" ],
+        "priority": 1,
+        "vendorPrefixes": [],
         "connection": {
           "http": {
             "uri": "http://iglucentral.com"

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/ConfigHelper.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/ConfigHelper.scala
@@ -29,14 +29,20 @@ import java.io.File
 
 import com.snowplowanalytics.iglu.client.IgluCirceClient
 import com.snowplowanalytics.iglu.client.resolver.Resolver
-
+import com.snowplowanalytics.iglu.client.resolver.registries.Registry
 import com.snowplowanalytics.snowplow.collectors.scalastream.model.{CollectorConfig, SinkConfig}
+
+import java.net.URI
 
 /** Contain functions to parse the command line arguments,
   * to parse the configuration for the collector, Akka HTTP and Iglu
   * and to instantiate Iglu client.
   */
 private[micro] object ConfigHelper {
+  object EnvironmentVariables {
+    val igluRegistryUrl = "MICRO_IGLU_REGISTRY_URL"
+    val igluApiKey = "MICRO_IGLU_API_KEY"
+  }
 
   implicit def hint[T] =
     ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
@@ -50,6 +56,13 @@ private[micro] object ConfigHelper {
       igluConfigFile: Option[File] = None,
       outputEnrichedTsv: Boolean = false
     )
+
+    def formatEnvironmentVariables(descriptions: (String, String)*): String = {
+      val longest = descriptions.map(_._1.length).max
+      descriptions.map {
+        case (envVar, desc) => s"  $envVar${" " * (longest - envVar.length)}  $desc"
+      }.mkString("\n")
+    }
 
     val parser = new scopt.OptionParser[MicroConfig](buildinfo.BuildInfo.name) {
       head(buildinfo.BuildInfo.name, buildinfo.BuildInfo.version)
@@ -71,7 +84,7 @@ private[micro] object ConfigHelper {
       opt[Option[File]]("iglu")
         .optional()
         .valueName("<filename>")
-        .text("Configuration file for Iglu igluClient")
+        .text("Configuration file for Iglu Client")
         .action((f: Option[File], c: MicroConfig) => c.copy(igluConfigFile = f))
         .validate(f =>
           f match {
@@ -85,28 +98,41 @@ private[micro] object ConfigHelper {
         .optional()
         .text("Print events in TSV format to standard output")
         .action((_, c: MicroConfig) => c.copy(outputEnrichedTsv = true))
-    }
-    
-    val (collectorFile, igluFile, outputEnrichedTsvEnabled) = parser.parse(args, MicroConfig()) match {
-      case Some(microConfig: MicroConfig) =>
-        (microConfig.collectorConfigFile, microConfig.igluConfigFile, microConfig.outputEnrichedTsv)
-      case None =>
-        throw new RuntimeException("Problem while parsing arguments") // should never be called
+      note(
+        "\nSupported environment variables:\n\n" + formatEnvironmentVariables(
+          EnvironmentVariables.igluRegistryUrl ->
+            "The URL for an additional custom Iglu registry",
+          EnvironmentVariables.igluApiKey ->
+            s"An optional API key for an Iglu registry defined with ${EnvironmentVariables.igluRegistryUrl}"
+        )
+      )
     }
 
-    val resolved = collectorFile match {
+    val config = parser.parse(args, MicroConfig()) getOrElse {
+      throw new RuntimeException("Problem while parsing arguments") // should never be called
+    }
+
+    val resolved = config.collectorConfigFile match {
       case Some(f) => ConfigFactory.parseFile(f).resolve()
       case None    => ConfigFactory.empty()
     }
 
     val collectorConfig = ConfigFactory.load(resolved.withFallback(ConfigFactory.load()))
 
-    val resolverSource = igluFile match {
+    val resolverSource = config.igluConfigFile match {
       case Some(f) => Source.fromFile(f)
       case None => Source.fromResource("default-iglu-resolver.json")
     }
 
-    val (resolver, igluClient) = getIgluClientFromSource(resolverSource) match {
+    val extraRegistry = sys.env.get(EnvironmentVariables.igluRegistryUrl).map { registry =>
+      val uri = URI.create(registry)
+      Registry.Http(
+        Registry.Config(s"Custom ($registry)", 0, List.empty),
+        Registry.HttpConnection(uri, sys.env.get(EnvironmentVariables.igluApiKey))
+      )
+    }
+
+    val (resolver, igluClient) = getIgluClientFromSource(resolverSource, extraRegistry) match {
       case Right(ok) => ok
       case Left(e) =>
         throw new IllegalArgumentException(s"Error while reading Iglu config file: $e.")
@@ -117,16 +143,17 @@ private[micro] object ConfigHelper {
       resolver,
       igluClient,
       collectorConfig,
-      outputEnrichedTsvEnabled
+      config.outputEnrichedTsv
     )
   }
 
   /** Instantiate an Iglu client from its configuration file. */
-  def getIgluClientFromSource(igluConfigSource: Source): Either[String, (Resolver[Id], IgluCirceClient[Id])] =
+  def getIgluClientFromSource(igluConfigSource: Source, extraRegistry: Option[Registry]): Either[String, (Resolver[Id], IgluCirceClient[Id])] =
     for {
       text <- Either.catchNonFatal(igluConfigSource.mkString).leftMap(_.getMessage)
       json <- parse(text).leftMap(_.show)
       config <- Resolver.parseConfig(json).leftMap(_.show)
       resolver <- Resolver.fromConfig[Id](config).leftMap(_.show).value
-    } yield (resolver, IgluCirceClient.fromResolver[Id](resolver, config.cacheSize))
+      completeResolver = resolver.copy(repos = resolver.repos ++ extraRegistry)
+    } yield (completeResolver, IgluCirceClient.fromResolver[Id](completeResolver, config.cacheSize))
 }


### PR DESCRIPTION
This offers an easy shortcut for those who don’t want to spell out a full Iglu config file.