### PR TITLE
Enable users to load their enrichments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+config/

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val buildSettings = Seq(
   scalaVersion := "2.12.14",
   scalacOptions := Settings.compilerOptions,
   javacOptions := Settings.javaCompilerOptions,
+  Runtime / unmanagedClasspath += baseDirectory.value / "config",
   resolvers ++= Dependencies.resolvers
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val dockerCommon = Seq(
   Docker / daemonUserUid := None,
   dockerRepository := Some("snowplow"),
   scriptClasspath += "/config",
+  Universal / javaOptions ++= Seq("-Dnashorn.args=--language=es6")
 )
 
 lazy val microSettingsDistroless = dockerCommon ++ Seq(
@@ -66,6 +67,7 @@ lazy val microSettingsDistroless = dockerCommon ++ Seq(
   Docker / daemonGroup := "nonroot",
   dockerEntrypoint := Seq(
     "java",
+    "-Dnashorn.args=--language=es6",
     "-cp",
     s"/opt/snowplow/lib/${(packageJavaClasspathJar / artifactPath).value.getName}:/config",
     "com.snowplowanalytics.snowplow.micro.Main"

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val dockerCommon = Seq(
   Docker / packageName := "snowplow/snowplow-micro",
   Docker / defaultLinuxInstallLocation := "/opt/snowplow",
   Docker / daemonUserUid := None,
+  dockerPermissionStrategy := DockerPermissionStrategy.CopyChown,
   dockerRepository := Some("snowplow"),
   scriptClasspath += "/config",
   Universal / javaOptions ++= Seq("-Dnashorn.args=--language=es6")
@@ -72,7 +73,6 @@ lazy val microSettingsDistroless = dockerCommon ++ Seq(
     s"/opt/snowplow/lib/${(packageJavaClasspathJar / artifactPath).value.getName}:/config",
     "com.snowplowanalytics.snowplow.micro.Main"
   ),
-  dockerPermissionStrategy := DockerPermissionStrategy.CopyChown,
   sourceDirectory := (micro / sourceDirectory).value
 )
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/ConfigHelper.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/ConfigHelper.scala
@@ -162,13 +162,13 @@ private[micro] object ConfigHelper {
         throw new IllegalArgumentException(s"Error while reading Iglu config file: $e.")
     }
 
-    val enrichmentDirectory = Option(getClass.getResource("/enrichments"))
-      .fold(Paths.get("."))(url => Paths.get(url.toURI))
-    val enrichmentConfigs = getEnrichmentRegistryFromPath(enrichmentDirectory, igluClient) match {
-      case Right(ok) => ok
-      case Left(e) =>
-        throw new IllegalArgumentException(s"Error while reading enrichment config file(s): $e.")
-    }
+    val enrichmentConfigs = Option(getClass.getResource("/enrichments")).map { dir =>
+      getEnrichmentRegistryFromPath(Paths.get(dir.toURI), igluClient) match {
+        case Right(ok) => ok
+        case Left(e) =>
+          throw new IllegalArgumentException(s"Error while reading enrichment config file(s): $e.")
+      }
+    }.getOrElse(List.empty)
 
     MicroConfig(
       ConfigSource.fromConfig(collectorConfig.getConfig("collector")).loadOrThrow[CollectorConfig],

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/ConfigHelper.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/ConfigHelper.scala
@@ -198,7 +198,8 @@ private[micro] object ConfigHelper {
       SchemaVer.Full(1, 0, 0)
     )
     // Loosely adapted from Enrich#localEnrichmentConfigsExtractor
-    Option(path.toFile.listFiles).fold(List.empty[File])(_.toList)
+    val directory = Option(path.toFile.listFiles).fold(List.empty[File])(_.toList)
+    val configs = directory
       .filter(_.getName.endsWith(".json"))
       .map(scala.io.Source.fromFile(_).mkString)
       .map(JsonUtils.extractJson).sequence[EitherS, Json]
@@ -207,5 +208,10 @@ private[micro] object ConfigHelper {
         EnrichmentRegistry.parse(jsonConfig, igluClient, localMode = false)
           .leftMap(_.toList.mkString("; ")).toEither
       }
+    val scripts = directory
+      .filter(_.getName.endsWith(".js"))
+      .map(scala.io.Source.fromFile(_).mkString)
+      .map(EnrichmentConf.JavascriptScriptConf(schemaKey, _))
+    configs.map(scripts ::: _)
   }
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Main.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Main.scala
@@ -14,17 +14,10 @@ package com.snowplowanalytics.snowplow.micro
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-
-import cats.Id
-
+import com.snowplowanalytics.snowplow.collectors.scalastream.model.CollectorSinks
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.Enrichment
+import com.snowplowanalytics.snowplow.micro.ConfigHelper.MicroConfig
 import org.slf4j.LoggerFactory
-
-import com.typesafe.config.Config
-
-import com.snowplowanalytics.iglu.client.IgluCirceClient
-import com.snowplowanalytics.iglu.client.resolver.Resolver
-
-import com.snowplowanalytics.snowplow.collectors.scalastream.model.{CollectorConfig, CollectorSinks}
 
 /** Read the configuration and instantiate Snowplow Micro,
   * which acts as a `Collector` and has an in-memory sink
@@ -35,31 +28,37 @@ object Main {
   lazy val logger = LoggerFactory.getLogger(getClass())
 
   def main(args: Array[String]): Unit = {
-    val (collectorConf, igluResolver, igluClient, akkaConf, outputEnrichedTsv) = ConfigHelper.parseConfig(args)
-    run(collectorConf, igluResolver, igluClient, akkaConf, outputEnrichedTsv)
+    val config = ConfigHelper.parseConfig(args)
+    run(config)
   }
 
   /** Create the in-memory sink,
     * get the endpoints for both the collector and to query Snowplow Micro,
     * and start the HTTP server.
     */
-  def run(
-    collectorConf: CollectorConfig,
-    igluResolver: Resolver[Id],
-    igluClient: IgluCirceClient[Id],
-    akkaConf: Config,
-    outputEnrichedTsv: Boolean
-  ): Unit = {
-    implicit val system = ActorSystem.create("snowplow-micro", akkaConf)
+  def run(config: MicroConfig): Unit = {
+    implicit val system = ActorSystem.create("snowplow-micro", config.akkaConfig)
     implicit val executionContext = system.dispatcher
 
-    val sinks = CollectorSinks(MemorySink(igluClient, outputEnrichedTsv), MemorySink(igluClient, outputEnrichedTsv))
-    val igluService = new IgluService(igluResolver)
+    val loadedEnrichments = config.enrichmentRegistry.productIterator.toList.collect {
+      case Some(e: Enrichment) => e.getClass.getSimpleName
+    }
+    if (loadedEnrichments.nonEmpty) {
+      logger.info(s"Enabled enrichments: ${loadedEnrichments.mkString(", ")}")
+    } else {
+      logger.info(s"No enrichments enabled.")
+    }
 
-    val routes = Routing.getMicroRoutes(collectorConf, sinks, igluService)
+    val sinks = CollectorSinks(
+      MemorySink(config.igluClient, config.enrichmentRegistry, config.outputEnrichedTsv),
+      MemorySink(config.igluClient, config.enrichmentRegistry, config.outputEnrichedTsv)
+    )
+    val igluService = new IgluService(config.igluResolver)
+
+    val routes = Routing.getMicroRoutes(config.collectorConfig, sinks, igluService)
 
     Http()
-      .newServerAt(collectorConf.interface, collectorConf.port)
+      .newServerAt(config.collectorConfig.interface, config.collectorConfig.port)
       .bind(routes)
       .foreach { binding =>
         logger.info(s"REST interface bound to ${binding.localAddress}")

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
@@ -41,9 +41,8 @@ import com.snowplowanalytics.snowplow.enrich.common.EtlPipeline
   * For each event it tries to validate it using Common Enrich,
   * and then stores the results in-memory in [[ValidationCache]].
   */
-private[micro] final case class MemorySink(igluClient: IgluCirceClient[Id], outputEnrichedTsv: Boolean) extends Sink {
+private[micro] final case class MemorySink(igluClient: IgluCirceClient[Id], enrichmentRegistry: EnrichmentRegistry[Id], outputEnrichedTsv: Boolean) extends Sink {
   val MaxBytes = Int.MaxValue
-  private val enrichmentRegistry = new EnrichmentRegistry[Id]()
   private val processor = Processor(buildinfo.BuildInfo.name, buildinfo.BuildInfo.version)
   private lazy val logger = LoggerFactory.getLogger("EventLog")
 

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
@@ -66,7 +66,7 @@ class MemorySinkSpec extends Specification {
       val withoutTimestamp = raw.copy(context = raw.context.copy(timestamp = None))
       val expected = "Error while validating the event"
       sink.validateEvent(withoutTimestamp, igluClient, enrichmentRegistry, processor) must beLeft.like {
-        case errors if errors.exists(_.contains(expected)) => ok
+        case (errors, _) if errors.exists(_.contains(expected)) => ok
         case errs => ko(s"$errs doesn't contain [$expected]")
       }
     }
@@ -76,7 +76,7 @@ class MemorySinkSpec extends Specification {
       val withoutEvent = raw.copy(parameters = raw.parameters - "e")
       val expected = "Error while validating the event"
       sink.validateEvent(withoutEvent, igluClient, enrichmentRegistry, processor) must beLeft.like {
-        case errors if errors.exists(_.contains(expected)) => ok
+        case (errors, _) if errors.exists(_.contains(expected)) => ok
         case errs => ko(s"$errs doesn't contain [$expected]")
       }
     }
@@ -85,7 +85,7 @@ class MemorySinkSpec extends Specification {
       val raw = buildRawEvent(Some(buildUnstruct(sdjInvalid)))
       val expected = "Error while validating the event"
       sink.validateEvent(raw, igluClient, enrichmentRegistry, processor) must beLeft.like {
-        case errors if errors.exists(_.contains(expected)) => ok
+        case (errors, _) if errors.exists(_.contains(expected)) => ok
         case errs => ko(s"$errs doesn't contain [$expected]")
       }
     }
@@ -94,7 +94,7 @@ class MemorySinkSpec extends Specification {
       val raw = buildRawEvent(None, Some(buildContexts(List(sdjInvalid))))
       val expected = "Error while validating the event"
       sink.validateEvent(raw, igluClient, enrichmentRegistry, processor) must beLeft.like {
-        case errors if errors.exists(_.contains(expected)) => ok
+        case (errors, _) if errors.exists(_.contains(expected)) => ok
         case errs => ko(s"$errs doesn't contain [$expected]")
       }
     }
@@ -103,7 +103,7 @@ class MemorySinkSpec extends Specification {
       val raw = buildRawEvent(Some(buildUnstruct(sdjDoesNotExist)))
       val expected = "Error while validating the event"
       sink.validateEvent(raw, igluClient, enrichmentRegistry, processor) must beLeft.like {
-        case errors if errors.exists(_.contains(expected)) => ok
+        case (errors, _) if errors.exists(_.contains(expected)) => ok
         case errs => ko(s"$errs doesn't contain [$expected]")
       }
     }
@@ -112,7 +112,7 @@ class MemorySinkSpec extends Specification {
       val raw = buildRawEvent(None, Some(buildContexts(List(sdjDoesNotExist))))
       val expected = "Error while validating the event"
       sink.validateEvent(raw, igluClient, enrichmentRegistry, processor) must beLeft.like {
-        case errors if errors.exists(_.contains(expected)) => ok
+        case (errors, _) if errors.exists(_.contains(expected)) => ok
         case errs => ko(s"$errs doesn't contain [$expected]")
       }
     }

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
@@ -30,7 +30,7 @@ class MemorySinkSpec extends Specification {
   private val igluClient = IgluCirceClient.fromResolver[Id](Resolver(List(Registry.IgluCentral), None), 500)
   private val enrichmentRegistry = new EnrichmentRegistry[Id]()
   private val processor = Processor(buildinfo.BuildInfo.name, buildinfo.BuildInfo.version)
-  private val sink = MemorySink(igluClient, outputEnrichedTsv = false)
+  private val sink = MemorySink(igluClient, enrichmentRegistry, outputEnrichedTsv = false)
 
   sequential
 


### PR DESCRIPTION
When running via `sbt run`, put the enrichment configurations (in .json) in `./config/enrichments`.
When running in Docker, mount a directory with the configurations to `/config/enrichments`.