### PR TITLE
Release 2.1.3 - Validate atomic fields lengths and max JSON depth with Enrich defaults

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Publish collector locally
       run: |
-        git clone --branch 3.2.0 --depth 1 https://github.com/snowplow/stream-collector.git
+        git clone --branch 3.3.0 --depth 1 https://github.com/snowplow/stream-collector.git
         cd stream-collector
         sbt +publishLocal
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Publish collector locally
       run: |
-        git clone --branch 3.2.0 --depth 1 https://github.com/snowplow/stream-collector.git
+        git clone --branch 3.3.0 --depth 1 https://github.com/snowplow/stream-collector.git
         cd stream-collector
         sbt +publishLocal
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Version 2.1.3 (2024-01-06)
+--------------------------
+Change SLULA license from 1.0 to 1.1
+Upgrade enrich to 5.2.0
+Upgrade collector to 3.3.0
+Validate atomic fields lengths and JSON depth with Enrich defaults
+Update instructions for local building
+
 Version 2.1.2 (2024-08-27)
 --------------------------
 Fix a regression with MICRO_IGLU_REGISTRY_URL

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,18 +1,20 @@
 # Snowplow Limited Use License Agreement
 
-_Version 1.0, January 2024_
+_Version 1.1, November, 2024_
 
-This Snowplow Limited Use License Agreement, Version 1.0 (the “Agreement”) sets forth the terms on which Snowplow Analytics, Ltd. (“Snowplow”) makes available certain software (the “Software”). BY INSTALLING, DOWNLOADING, ACCESSING, OR USING ANY OF THE SOFTWARE, YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY. “Licensee” means you, an individual, or the entity on whose behalf you are receiving the Software.
+This Snowplow Limited Use License Agreement, Version 1.1 (the “Agreement”) sets forth the terms on which Snowplow Analytics, Ltd. (“Snowplow”) makes available certain software (the “Software”). BY INSTALLING, DOWNLOADING, ACCESSING, OR USING ANY OF THE SOFTWARE, YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY. “Licensee” means you, an individual, or the entity on whose behalf you are receiving the Software.
 
-## LICENSE GRANT AND CONDITIONS
+## 1. LICENSE GRANT AND CONDITIONS
 
-**1.1 License.** Subject to the terms and conditions of this Agreement, Snowplow hereby grants to Licensee a non-exclusive, royalty-free, worldwide, non-transferable, non-sublicensable license during the term of this Agreement to: (a) use the Software; (b) prepare modifications and derivative works of the Software; and (c) reproduce copies of the Software (the “License”). No right to distribute or make available the Software is granted under this License. Licensee is not granted the right to, and Licensee shall not, exercise the License for any Excluded Purpose.
+**1.1 License.** Subject to the terms and conditions of this Agreement, Snowplow hereby grants to Licensee a non-exclusive, royalty-free, worldwide, non-transferable, non-sublicensable license during the term of this Agreement to: (a) use the Software; (b) prepare modifications and derivative works of the Software; and (c) reproduce copies of the Software (the “License”). No right to distribute or make available the Software is granted under this License. Licensee is not granted the right to, and Licensee shall not, exercise the License for any Competing Use, and Licensee may exercise the License only for Non-Production Use or Non-Commercial Use.
 
-**1.2** For purposes of this Agreement, an “Excluded Purpose” is any use that is either a Competing Use or a Highly-Available Production Use, or both of them.
+**1.2 Definitions.** For purposes of this Agreement:
 
-* **1.2.1** A “Competing Use” is making available any on-premises or distributed software product, or any software-as-a-service, platform-as-a-service, infrastructure-as-a-service, or other similar online service, that competes with any products or services that Snowplow or any of its affiliates provides using the Software.
+* **1.2.1** “Competing Use” is making available any on-premises or distributed software product, or any software-as-a-service, platform-as-a-service, infrastructure-as-a-service, or other similar online service, that competes with any products or services that Snowplow or any of its affiliates provides using the Software.
 
-* **1.2.2** Highly-Available Production Use is any highly-available use, including without limitation any use where multiple instances of any Software component run concurrently to avoid a single point of failure, in a production environment, where production means use on live data.
+* **1.2.2** “Non-Production Use” means any use of the Software to process test or synthetic data to evaluate the sufficiency of the Software for use by Licensee.
+
+* **1.2.3** “Non-Commercial Use” is only: (a) personal use for research, experiment, personal study, or hobby projects, without any anticipated commercial application, or (b) use for teaching purposes by lecturers of a school or university.
 
 **1.3 Conditions.** In consideration of the License, Licensee’s use of the Software is subject to the following conditions:
 
@@ -22,8 +24,8 @@ This Snowplow Limited Use License Agreement, Version 1.0 (the “Agreement”) s
 
   ```
   This software is made available by Snowplow Analytics, Ltd.,
-  under the terms of the Snowplow Limited Use License Agreement, Version 1.0
-  located at https://docs.snowplow.io/limited-use-license-1.0
+  under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+  located at https://docs.snowplow.io/limited-use-license-1.1
   BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
   OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
   ```
@@ -32,23 +34,23 @@ This Snowplow Limited Use License Agreement, Version 1.0 (the “Agreement”) s
 
 **1.5 No Sublicensing.** The License does not include the right to sublicense the Software, however, each recipient to which Licensee provides the Software may exercise the Licenses so long as such recipient agrees to the terms and conditions of this Agreement.
 
-## TERM AND TERMINATION
+## 2. TERM AND TERMINATION
 
 This Agreement will continue unless and until earlier terminated as set forth herein. If Licensee breaches any of its conditions or obligations under this Agreement, this Agreement will terminate automatically and the License will terminate automatically and permanently.
 
-## INTELLECTUAL PROPERTY
+## 3. INTELLECTUAL PROPERTY
 
 As between the parties, Snowplow will retain all right, title, and interest in the Software, and all intellectual property rights therein. Snowplow hereby reserves all rights not expressly granted to Licensee in this Agreement. Snowplow hereby reserves all rights in its trademarks and service marks, and no licenses therein are granted in this Agreement.
 
-## DISCLAIMER
+## 4. DISCLAIMER
 
 SNOWPLOW HEREBY DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, WITH RESPECT TO THE SOFTWARE.
 
-## LIMITATION OF LIABILITY
+## 5. LIMITATION OF LIABILITY
 
 SNOWPLOW WILL NOT BE LIABLE FOR ANY DAMAGES OF ANY KIND, INCLUDING BUT NOT LIMITED TO LOST PROFITS OR ANY CONSEQUENTIAL, SPECIAL, INCIDENTAL, INDIRECT, OR DIRECT DAMAGES, HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ARISING OUT OF THIS AGREEMENT. THE FOREGOING SHALL APPLY TO THE EXTENT PERMITTED BY APPLICABLE LAW.
 
-## GENERAL
+## 6. GENERAL
 
 **6.1 Governing Law.** This Agreement will be governed by and interpreted in accordance with the laws of the state of Delaware, without reference to its conflict of laws principles. If Licensee is located within the United States, all disputes arising out of this Agreement are subject to the exclusive jurisdiction of courts located in Delaware, USA. If Licensee is located outside of the United States, any dispute, controversy or claim arising out of or relating to this Agreement will be referred to and finally determined by arbitration in accordance with the JAMS International Arbitration Rules. The tribunal will consist of one arbitrator. The place of arbitration will be in the State of Delaware, USA. The language to be used in the arbitral proceedings will be English. Judgment upon the award rendered by the arbitrator may be entered in any court having jurisdiction thereof.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then clone the repository and publish the Collector dependency locally:
 git clone git@github.com:snowplow-incubator/snowplow-micro.git
 cd snowplow-micro
 
-git clone --branch 3.2.0 --depth 1 git@github.com:snowplow/stream-collector.git
+git clone --branch 3.3.0 --depth 1 git@github.com:snowplow/stream-collector.git
 cd stream-collector
 sbt +publishLocal && cd ..
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Licensed under the [Snowplow Limited Use License Agreement][license]. _(If you a
 [gh-actions-image]: https://github.com/snowplow-incubator/snowplow-micro/actions/workflows/test.yml/badge.svg?branch=master
 [gh-releases]: https://github.com/snowplow-incubator/snowplow-micro/releases
 
-[license]: https://docs.snowplow.io/limited-use-license-1.0
+[license]: https://docs.snowplow.io/limited-use-license-1.1
 [license-image]: https://img.shields.io/badge/license-Snowplow--Limited--Use-blue.svg?style=flat
 [faq]: https://docs.snowplow.io/docs/contributing/limited-use-license-faq/
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   object V {
     // Snowplow
     val snowplowStreamCollector = "3.3.0"
-    val snowplowCommonEnrich    = "5.1.4"
+    val snowplowCommonEnrich    = "5.2.0"
     val http4sCirce             = "0.23.23"
 
     val decline          = "2.4.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   object V {
     // Snowplow
     val snowplowStreamCollector = "3.2.0"
-    val snowplowCommonEnrich    = "4.2.0"
+    val snowplowCommonEnrich    = "5.1.4"
     val http4sCirce             = "0.23.23"
 
     val decline          = "2.4.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
 
   object V {
     // Snowplow
-    val snowplowStreamCollector = "3.2.0"
+    val snowplowStreamCollector = "3.3.0"
     val snowplowCommonEnrich    = "5.1.4"
     val http4sCirce             = "0.23.23"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -25,13 +25,13 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 object Settings {
 
   lazy val licenseSettings = Seq(
-    licenses += ("Snowplow Limited Use License Agreement", url("https://docs.snowplow.io/limited-use-license-1.0")),
+    licenses += ("Snowplow Limited Use License Agreement", url("https://docs.snowplow.io/limited-use-license-1.1")),
     headerLicense := Some(HeaderLicense.Custom(
       """|Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
          |
          |This software is made available by Snowplow Analytics, Ltd.,
-         |under the terms of the Snowplow Limited Use License Agreement, Version 1.0
-         |located at https://docs.snowplow.io/limited-use-license-1.0
+         |under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+         |located at https://docs.snowplow.io/limited-use-license-1.1
          |BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
          |OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
          |""".stripMargin

--- a/src/main/resources/collector-micro.conf
+++ b/src/main/resources/collector-micro.conf
@@ -1,8 +1,8 @@
 # Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
 #
 # This software is made available by Snowplow Analytics, Ltd.,
-# under the terms of the Snowplow Limited Use License Agreement, Version 1.0
-# located at https://docs.snowplow.io/limited-use-license-1.0
+# under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+# located at https://docs.snowplow.io/limited-use-license-1.1
 # BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
 # OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
 

--- a/src/main/resources/default-iglu-resolver.conf
+++ b/src/main/resources/default-iglu-resolver.conf
@@ -1,8 +1,8 @@
 # Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
 #
 # This software is made available by Snowplow Analytics, Ltd.,
-# under the terms of the Snowplow Limited Use License Agreement, Version 1.0
-# located at https://docs.snowplow.io/limited-use-license-1.0
+# under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+# located at https://docs.snowplow.io/limited-use-license-1.1
 # BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
 # OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/EventConverter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/EventConverter.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/decode/GenericConverter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/decode/GenericConverter.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/decode/RowConverter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/decode/RowConverter.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/decode/ValueConverter.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/decode/ValueConverter.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Configuration.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Configuration.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Main.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Main.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/MemorySink.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/MicroHttpServer.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/MicroHttpServer.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Routing.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Routing.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -18,7 +18,6 @@ import com.snowplowanalytics.iglu.client.resolver.registries.JavaNetRegistryLook
 import com.snowplowanalytics.snowplow.badrows.Processor
 import com.snowplowanalytics.snowplow.collector.core._
 import com.snowplowanalytics.snowplow.collector.core.model.Sinks
-import com.snowplowanalytics.snowplow.enrich.common.adapters.AdapterRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{Enrichment, EnrichmentConf}
 import com.snowplowanalytics.snowplow.enrich.common.utils.{HttpClient, ShiftExecution}
@@ -56,9 +55,8 @@ object Run {
       sslContext <- Resource.eval(setupSSLContext())
       enrichmentRegistry <- buildEnrichmentRegistry(config.enrichmentsConfig)
       badProcessor = Processor(BuildInfo.name, BuildInfo.version)
-      adapterRegistry = new AdapterRegistry[IO](Map.empty, config.adaptersSchemas.adaptersSchemas)
       lookup = JavaNetRegistryLookup.ioLookupInstance[IO]
-      sink = new MemorySink(config.iglu.client, lookup, enrichmentRegistry, config.outputEnrichedTsv, badProcessor, adapterRegistry)
+      sink = new MemorySink(config.iglu.client, lookup, enrichmentRegistry, config.outputEnrichedTsv, badProcessor, config.enrichConfig)
       collectorService = new Service[IO](
         config.collector,
         Sinks(sink, sink),

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -66,7 +66,6 @@ object Run {
         config.collector.enableDefaultRedirect,
         config.collector.rootResponse.enabled,
         config.collector.crossDomain.enabled,
-        config.collector.networking.bodyReadTimeout,
         collectorService
       ).value
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/ValidationCache.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/ValidationCache.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/model.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/model.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/EventConverterSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.analytics.scalasdk/EventConverterSpec.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/ConfigHelperSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/ConfigHelperSpec.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/MicroApiSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/MicroApiSpec.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/TestAdapterRegistry.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/TestAdapterRegistry.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/ValidationCacheSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/ValidationCacheSpec.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/events.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/events.scala
@@ -2,8 +2,8 @@
  * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This software is made available by Snowplow Analytics, Ltd.,
- * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
- * located at https://docs.snowplow.io/limited-use-license-1.0
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
  * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
  * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
  */


### PR DESCRIPTION
Use defaults from https://github.com/snowplow/enrich-private/blob/PDP-1583_mico_atomic_lengths/modules/common/src/main/resources/reference.conf#L152-L240