### PR TITLE
Fix logging by upgrading slf4j-simple

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ lazy val dependencies = Seq(
     Dependencies.circeGeneric,
     Dependencies.specs2,
     Dependencies.specs2CE,
-    Dependencies.badRows
+    Dependencies.badRows,
+    Dependencies.slf4jSimple
   )
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,6 +21,7 @@ object Dependencies {
     val http4sCirce             = "0.23.23"
 
     val decline          = "2.4.1"
+    val slf4j            = "2.0.17"
     
     // circe
     val circe = "0.14.2"
@@ -38,6 +39,7 @@ object Dependencies {
   
   val http4sCirce = "org.http4s"    %% "http4s-circe"   % V.http4sCirce 
   val decline     = "com.monovore"  %% "decline-effect" % V.decline
+  val slf4jSimple = "org.slf4j"     %  "slf4j-simple"   % V.slf4j
 
   // circe
   val circeJawn    = "io.circe" %% "circe-jawn"    % V.circe


### PR DESCRIPTION
Jira ref: PDP-1780

Stdout logging has been broken since the 2.1.3 release.

Before this PR:

```
docker run snowplow/snowplow/snowplow-micro:2.1.3
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/opt/snowplow/lib/org.slf4j.slf4j-simple-1.7.32.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

After this PR:

```
docker run snowplow/snowplow/snowplow-micro:dev
[INFO] com.snowplowanalytics.snowplow.micro.Run - No enrichments enabled
[INFO] com.snowplowanalytics.snowplow.micro.MicroHttpServer - Building blaze server
[INFO] org.http4s.blaze.channel.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:9090
[INFO] org.http4s.blaze.server.BlazeServerBuilder - 
  _   _   _        _ _
 | |_| |_| |_ _ __| | | ___
 | ' \  _|  _| '_ \_  _(_-<
 |_||_\__|\__| .__/ |_|/__/
             |_|
[INFO] org.http4s.blaze.server.BlazeServerBuilder - http4s v0.23.25 on blaze v0.23.15 started at http://[::]:9090/

```