### PR TITLE
Bump Enrich to 5.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,9 @@ lazy val buildSettings = Seq(
   ),
   Compile / unmanagedResources += file("LICENSE.md"),
   resolvers ++= Dependencies.resolvers,
-  Test / parallelExecution := false
+  Test / parallelExecution := false,
+  Test / javaOptions := Seq("-Dnashorn.args=--language=es6"),
+  Test / fork := true
 )
 
 lazy val dependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   object V {
     // Snowplow
     val snowplowStreamCollector = "3.3.0"
-    val snowplowCommonEnrich    = "5.2.0"
+    val snowplowCommonEnrich    = "5.3.0"
     val http4sCirce             = "0.23.23"
 
     val decline          = "2.4.1"

--- a/src/test/resources/js-enrichment.js
+++ b/src/test/resources/js-enrichment.js
@@ -1,0 +1,8 @@
+function process(event) {
+  if (event.getApp_id() === "drop-all") {
+    event.drop()
+  }
+
+  return [];
+};
+

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/events.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/events.scala
@@ -67,12 +67,13 @@ object events {
   }
   """
 
-  def buildRawEvent(unstruct: Option[String] = None, contexts: Option[String] = None): RawEvent = {
+  def buildRawEvent(unstruct: Option[String] = None, contexts: Option[String] = None, appId: String = "shop"): RawEvent = {
     val collectorApi = Api("com.snowplowanalytics.snowplow", "tp2")
     var params = Map(
       "tv" -> "tracker v42",
       "p" -> "web",
-      "e" -> "pp"
+      "e" -> "pp",
+      "aid" -> appId
     )
 
     params = unstruct match {


### PR DESCRIPTION
Enrich 5.3.0 includes the new feature of dropping events via the javascript enrichment. This commit updates Micro to handle and ignore dropped events in the micro API.