### PR TITLE
Change github action runner to ubuntu-latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -25,6 +25,9 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+
+    - name: Install sbt
+      uses: sbt/setup-sbt@v1
 
     - name: Publish collector locally
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -15,6 +15,9 @@ jobs:
       with:
         java-version: 11
         distribution: adopt
+
+    - name: Install sbt
+      uses: sbt/setup-sbt@v1
 
     - name: Publish collector locally
       run: |


### PR DESCRIPTION
Without this change, the github action fails with:

> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.